### PR TITLE
Adds linked video icon next to Lecture & Lab headings if Video link available

### DIFF
--- a/data/lectures.yml
+++ b/data/lectures.yml
@@ -3,6 +3,7 @@
   Events:
     2015-01-28:
       Label: Lecture
+      Video: "http://techtalks.tv/talks/lecture-1-9/61380/"
       Topics:
         Course mechanics:
           References (Supplemental):
@@ -26,6 +27,7 @@
             - {Stochastic Gradient Descent: "docs/stoch-grad-descent.pdf"}
     2015-01-29:
       Label: Lab
+      Video: "http://techtalks.tv/talks/lab-1/61381/"
       Topics:
         Matrix differentiation (Shanshan Ding):
           References (Supplemental):

--- a/styles/phone.styl
+++ b/styles/phone.styl
@@ -108,13 +108,15 @@ body > nav
       h1
         padding-left: 20px
 
-    .icon::before
-      top: 0
-      left: 0
+    .icon
+      &.references, &.slides
+        &::before
+          top: 0
+          left: 0
 
-      margin-top: -6px
+          margin-top: -6px
 
-      font-size: 14px
+          font-size: 14px
 
 #assignments .homework
   strong

--- a/styles/style.styl
+++ b/styles/style.styl
@@ -58,6 +58,8 @@ icon-new-window =
   content: "\e164"
 icon-save =
   content: "\e166"
+icon-video =
+  content: "\e059"
 
 
 *, *::before, *::after
@@ -368,6 +370,10 @@ body > section
   h1
     margin-bottom: 15px
 
+    .video
+      margin-left: 2px
+      vertical-align: 1px
+
   .date
     display: block
     margin-top: 5px
@@ -385,18 +391,26 @@ body > section
     content: "(None)"
 
   .icon
-    &::before
-      position: absolute
-      left: -42px
-      top: 20px
+    &.references, &.slides
+      &::before
+        position: absolute
+        left: -42px
+        top: 20px
 
-      font-size: 30px
+        font-size: 30px
 
     &.references::before
       {icon-book}
 
     &.slides::before
       {icon-pencil}
+
+    &.video
+      &::before
+        {icon-video}
+
+      &:hover::before
+        opacity: 1
 
   > section
     display: table-row

--- a/templates/lectures.hbs
+++ b/templates/lectures.hbs
@@ -4,7 +4,13 @@
 
         {{#each Events}}
             <section>
-                <div class="label"><h1>{{Label}} <span class="date">{{shortDate @key}}</span></h1></div>
+                <div class="label">
+                    <h1>
+                        {{Label}}
+                        {{#if Video}}<a href="{{Video}}" class="video"><span class="video icon"></span></a>{{/if}}
+                        <span class="date">{{shortDate @key}}</span>
+                    </h1>
+                </div>
                 <div class="topics">
                     <ul>
                         {{#each Topics}}


### PR DESCRIPTION
- Adds "Video" field to lecture .yml
- Adds linked video icon next to Lecture & Lab headings if Video link available
- Fixes #32

Is this too unobtrusive?
![screen shot 2015-02-08 at 9 26 04 pm](https://cloud.githubusercontent.com/assets/560547/6100246/6db85114-afd9-11e4-925f-54579f13dae3.png)
